### PR TITLE
wait a little longer for replies

### DIFF
--- a/network.py
+++ b/network.py
@@ -38,7 +38,7 @@ class Network:
         # Receiving socket
         self.rs = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.rs.bind((Network.BROADCAST_ADDR, Network.UDP_RECEIVE_FROM_PORT))
-        self.rs.settimeout(0.5)
+        self.rs.settimeout(10)
 
     def send(self, op_code, payload):
         self.sequence_id = (self.sequence_id + 1) % 1000


### PR DESCRIPTION
this is especially required when the switch has to actually apply changes (e.g. toggling between changing pvid with ./smrt.py ... pvid --vlan 4 --vlan_pvid 3,4 then --vlan 1)

as you can see in this packet capture, the original wait time of 0.5 seconds was not enough because it actually took it 0.7 seconds to reply:

![image](https://user-images.githubusercontent.com/43356/117562024-b8150b00-b093-11eb-9ed1-4e3a13072e90.png)

I've set this to 10 seconds because I've seen it take 2 seconds to apply the config, so to be safe, I've bumped it considerably.